### PR TITLE
Fixing sending in hubot-framework.

### DIFF
--- a/src/adapter.coffee
+++ b/src/adapter.coffee
@@ -78,7 +78,7 @@ class BotFrameworkAdapter extends Adapter
         for msg in messages
             channelId = msg.channelId || '*'
             payload = @using(channelId).toSendable(context, msg)
-            if !Array.isArray(messages)
+            if !Array.isArray(payload)
               payload = [payload]
             @connector.send payload, (err, _) -> throw err if err
 


### PR DESCRIPTION
This was causing a failure before:
if !Array.isArray(messages) 
    payload = [payload] 
@connector.send payload, (err, _) -> throw err if err 

messages is always an array so payload was never being wrapped in [] causing ChatConnector to fail trying to find the address because it was expecting an array of messages instead of a single one.