### PR TITLE
Fix clientActivityId being null. It is not guaranteed to be present for all channels.

### DIFF
--- a/src/adapter-middleware.coffee
+++ b/src/adapter-middleware.coffee
@@ -28,7 +28,10 @@ class TextMiddleware extends BaseMiddleware
         user.activity = activity
 
         if activity.type == 'message'
-            return new TextMessage(user, activity.text, activity.sourceEvent.clientActivityId)
+            messageId = activity.sourceEvent?.clientActivityId
+            if not messageId?
+                messageId = 'message-id'
+            return new TextMessage(user, activity.text, messageId)
         
         return new Message(user)
     

--- a/src/adapter-middleware.coffee
+++ b/src/adapter-middleware.coffee
@@ -28,10 +28,7 @@ class TextMiddleware extends BaseMiddleware
         user.activity = activity
 
         if activity.type == 'message'
-            messageId = activity.sourceEvent?.clientActivityId
-            if not messageId?
-                messageId = 'message-id'
-            return new TextMessage(user, activity.text, messageId)
+            return new TextMessage(user, activity.text, activity.sourceEvent?.clientActivityId || '')
         
         return new Message(user)
     

--- a/test/adapter-middleware.test.coffee
+++ b/test/adapter-middleware.test.coffee
@@ -1,0 +1,182 @@
+chai = require 'chai'
+expect = chai.expect
+{ TextMessage, Message, User } = require 'hubot'
+MockRobot = require './mock-robot'
+{ BaseMiddleware, TextMiddleware, middlewareFor } = require '../src/adapter-middleware'
+
+describe 'middlewareFor', ->
+    it 'should return Middleware for null', ->
+        middleware = middlewareFor(null)
+        expect(middleware).to.be.not.null
+
+    it 'should return Middleware for any string', ->
+        middleware = middlewareFor("null")
+        expect(middleware).to.be.not.null
+
+    it 'should return Middleware for proper channel', ->
+        middleware = middlewareFor("msteams")
+        expect(middleware).to.be.not.null
+        
+
+describe 'BaseMiddleware', ->
+    describe 'toReceivable', ->
+        robot = null
+        event = null
+        beforeEach ->
+            robot = new MockRobot
+            event =
+                type: 'message'
+                text: 'Bot do something and tell User about it'
+                agent: 'tests'
+                source: '*'
+                address:
+                    conversation:
+                        id: "conversation-id"
+                    bot:
+                        id: "bot-id"
+                    user:
+                        id: "user-id"
+                        name: "user-name"
+
+        it 'should throw', ->
+            middleware = new BaseMiddleware(robot)
+            expect(() ->
+                middleware.toReceivable(event)
+            ).to.throw()
+
+    describe 'toSendable', ->
+        robot = null
+        message = null
+        context = null
+        beforeEach ->
+            robot = new MockRobot
+            context =
+                user:
+                    id: 'user-id'
+                    name: 'user-name'
+                    activity:
+                        type: 'message'
+                        text: 'Bot do something and tell User about it'
+                        agent: 'tests'
+                        source: '*'
+                        address:
+                            conversation:
+                                id: "conversation-id"
+                            bot:
+                                id: "bot-id"
+                            user:
+                                id: "user-id"
+                                name: "user-name"
+            message = "message"
+
+        it 'should throw', ->
+            middleware = new BaseMiddleware(robot)
+            expect(() ->
+                middleware.toSendable(context, message)
+            ).to.throw()
+
+describe 'TextMiddleware', ->
+    describe 'toReceivable', ->
+        robot = null
+        event = null
+        beforeEach ->
+            robot = new MockRobot
+            event =
+                type: 'message'
+                text: 'Bot do something and tell User about it'
+                agent: 'tests'
+                source: '*'
+                address:
+                    conversation:
+                        id: "conversation-id"
+                    bot:
+                        id: "bot-id"
+                    user:
+                        id: "user-id"
+                        name: "user-name"
+
+        it 'return generic message when appropriate type is not found', ->
+            # Setup
+            event.type = 'typing'
+            middleware = new TextMiddleware(robot)
+
+            # Action
+            receivable = null
+            expect(() ->
+                receivable = middleware.toReceivable(event)
+            ).to.not.throw()
+
+            # Assert
+            expect(receivable).to.be.not.null
+
+        it 'return message when type is message', ->
+            # Setup
+            middleware = new TextMiddleware(robot)
+
+            # Action
+            receivable = null
+            expect(() ->
+                receivable = middleware.toReceivable(event)
+            ).to.not.throw()
+
+            # Assert
+            expect(receivable).to.be.not.null
+
+    describe 'toSendable', ->
+        robot = null
+        message = null
+        context = null
+        beforeEach ->
+            robot = new MockRobot
+            context =
+                user:
+                    id: 'user-id'
+                    name: 'user-name'
+                    activity:
+                        type: 'message'
+                        text: 'Bot do something and tell User about it'
+                        agent: 'tests'
+                        source: '*'
+                        address:
+                            conversation:
+                                id: "conversation-id"
+                            bot:
+                                id: "bot-id"
+                            user:
+                                id: "user-id"
+                                name: "user-name"
+            message = "message"
+
+        it 'should create message object for string messages', ->
+            # Setup
+            middleware = new TextMiddleware(robot)
+
+            # Action
+            sendable = null
+            expect(() ->
+                sendable = middleware.toSendable(context, message)
+            ).to.not.throw()
+
+            # Verify
+            expected = {
+                type: 'message'
+                text: message
+                address: context.user.activity.address
+            }
+            expect(sendable).to.deep.equal(expected)
+
+        it 'should not alter non-string messages', ->
+            # Setup
+            message =
+              type: "some message type"
+            middleware = new TextMiddleware(robot)
+
+            # Action
+            sendable = null
+            expect(() ->
+                sendable = middleware.toSendable(context, message)
+            ).to.not.throw()
+
+            # Verify
+            expected = message
+            expect(sendable).to.deep.equal(expected)

--- a/test/msteams-middleware.test.coffee
+++ b/test/msteams-middleware.test.coffee
@@ -37,9 +37,9 @@ describe 'MicrosoftTeamsMiddleware', ->
                         id: "19:conversation-id"
                     bot:
                         id: "bot-id"
-                user:
-                    id: "user-id"
-                    name: "user-name"
+                    user:
+                        id: "user-id"
+                        name: "user-name"
 
         it 'should allow messages without tenant id when tenant filter is empty', ->
             # Setup
@@ -171,7 +171,7 @@ describe 'MicrosoftTeamsMiddleware', ->
 
         it 'should prepend bot name in 1:1 chats', ->
             # Setup
-            event.address.conversation.id = event.user.id
+            event.address.conversation.id = event.address.user.id
             event.text = 'do something <at>Bot</at> and tell <at>User</at> about it'
             teamsMiddleware = new MicrosoftTeamsMiddleware(robot)
 
@@ -221,9 +221,9 @@ describe 'MicrosoftTeamsMiddleware', ->
                                 id: "19:conversation-id"
                             bot:
                                 id: "bot-id"
-                        user:
-                            id: "user-id"
-                            name: "user-name"
+                            user:
+                                id: "user-id"
+                                name: "user-name"
             message = "message"
 
         it 'should create message object for string messages', ->


### PR DESCRIPTION
If client activity id is null then just use generic 'messageId' as the id for the message.
Add tests to ensure we don't regress.