### PR TITLE
Adapter handling of both persistent and non-persistent brains when using authorization

### DIFF
--- a/src/adapter.coffee
+++ b/src/adapter.coffee
@@ -30,8 +30,8 @@ class BotFrameworkAdapter extends Adapter
         @initialAdmins = process.env.HUBOT_TEAMS_INITIAL_ADMINS
         robot.logger.info "#{LogPrefix} Adapter loaded. Using appId #{@appId}"
 
-        # Initial Admins should be required when auth is enabled
-        @robot.brain.on( "loaded", () =>
+        # When the adapter is ready to be run, load the authorized users if needed
+        @on( "loadAuthorizedUsers", () =>
             if @enableAuth
                 if @initialAdmins?
                     # If there isn't a list of authorized users in the brain, populate
@@ -93,6 +93,7 @@ class BotFrameworkAdapter extends Adapter
             middleware.send(@connector, payload)
 
     run: ->
+        @emit "loadAuthorizedUsers"
         @robot.router.post @endpoint, @connector.listen()
         @robot.logger.info "#{LogPrefix} Adapter running."
         Timers.setTimeout (=> @emit "connected"), 1000

--- a/src/msteams-middleware.coffee
+++ b/src/msteams-middleware.coffee
@@ -66,7 +66,12 @@ class MicrosoftTeamsMiddleware extends BaseMiddleware
 
         # Get the user
         user = getUser(activity)
+        
+        # Store the UPN temporarily to re-add it to user and ensure
+        # the user has a UPN.
+        upn = user.userPrincipalName
         user = @robot.brain.userForId(user.id, user)
+        user.userPrincipalName = upn
 
         # We don't want to save the activity or room in the brain since its
         # something that changes per chat.

--- a/test/adapter.test.coffee
+++ b/test/adapter.test.coffee
@@ -15,10 +15,13 @@ describe 'Main Adapter', ->
             # Setup
             delete process.env.HUBOT_TEAMS_ENABLE_AUTH
             robot = new MockRobot
+            adapter = BotFrameworkAdapter.use(robot)
+            adapter.run = () ->
+                @emit "loadAuthorizedUsers"
 
             # Action
             expect(() ->
-                adapter = BotFrameworkAdapter.use(robot)
+                adapter.run(robot)
             ).to.not.throw()
 
             # Assert
@@ -28,32 +31,41 @@ describe 'Main Adapter', ->
             # Setup
             process.env.HUBOT_TEAMS_ENABLE_AUTH = 'false'
             robot = new MockRobot
+            adapter = BotFrameworkAdapter.use(robot)
+            adapter.run = () ->
+                @emit "loadAuthorizedUsers"
 
             # Action
             expect(() ->
-                adapter = BotFrameworkAdapter.use(robot)
+                adapter.run(robot)
             ).to.not.throw()
 
             # Assert
             expect(robot.brain.get("authorizedUsers")).to.be.null
         
-        it 'should throw error when auth is enabled and initial admins', ->
+        it 'should throw error when auth is enabled and initial admins is not set', ->
             # Setup
             delete process.env.HUBOT_TEAMS_INITIAL_ADMINS
             robot = new MockRobot
+            adapter = BotFrameworkAdapter.use(robot)
+            adapter.run = () ->
+                @emit "loadAuthorizedUsers"
 
             # Action and Assert
             expect(() ->
-                adapter = BotFrameworkAdapter.use(robot)
+                adapter.run(robot)
             ).to.throw()
 
         it 'should set initial admins when auth is enabled', ->
             # Setup
             robot = new MockRobot
+            adapter = BotFrameworkAdapter.use(robot)
+            adapter.run = () ->
+                @emit "loadAuthorizedUsers"
 
             # Action
             expect(() ->
-                adapter = BotFrameworkAdapter.use(robot)
+                adapter.run(robot)
             ).to.not.throw()
 
             # Assert


### PR DESCRIPTION
Allows the adapter to handle both persistent and non-persistent brains when loading the authorized users.